### PR TITLE
Implement desktop scene with window manager (Issue #1)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="DeltaTerminal"
+run/main_scene="res://scenes/desktop/desktop.tscn"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/desktop/crt_background.gdshader
+++ b/scenes/desktop/crt_background.gdshader
@@ -1,0 +1,24 @@
+shader_type canvas_item;
+
+uniform vec4 base_color : source_color = vec4(0.02, 0.06, 0.02, 1.0);
+uniform float scanline_intensity : hint_range(0.0, 0.3) = 0.08;
+uniform float scanline_frequency : hint_range(50.0, 600.0) = 300.0;
+uniform float noise_intensity : hint_range(0.0, 0.1) = 0.015;
+uniform float vignette_strength : hint_range(0.0, 1.0) = 0.35;
+
+void fragment() {
+	// Scanlines
+	float scanline = sin(UV.y * scanline_frequency * PI) * 0.5 + 0.5;
+	float scan = 1.0 - scanline * scanline_intensity;
+
+	// Animated static noise
+	float noise = fract(sin(dot(UV * 300.0 + TIME * 0.3, vec2(12.9898, 78.233))) * 43758.5453);
+	float n = (noise - 0.5) * noise_intensity;
+
+	// Vignette
+	vec2 vig = UV * 2.0 - 1.0;
+	float vignette = 1.0 - dot(vig, vig) * vignette_strength;
+
+	vec3 col = (base_color.rgb + vec3(0.0, n, 0.0)) * scan * vignette;
+	COLOR = vec4(col, 1.0);
+}

--- a/scenes/desktop/crt_background.gdshader.uid
+++ b/scenes/desktop/crt_background.gdshader.uid
@@ -1,0 +1,1 @@
+uid://b0bc2h4d8a5fo

--- a/scenes/desktop/desktop.gd
+++ b/scenes/desktop/desktop.gd
@@ -1,0 +1,50 @@
+class_name Desktop
+extends Control
+## Root desktop scene — the in-game OS shell.
+## Hosts the WindowManager, Taskbar, and right-click context menu.
+
+@onready var window_manager: WindowManager = $WindowLayer
+@onready var context_menu: PopupMenu = $ContextMenu
+
+
+func _ready() -> void:
+	GameManager.transition_to(GameManager.State.DESKTOP)
+	_setup_context_menu()
+
+
+func _setup_context_menu() -> void:
+	context_menu.clear()
+	# Stubs — populate with real tool scenes as they are built
+	context_menu.add_item("Open Terminal", 0)
+	context_menu.add_item("Open Network Map", 1)
+	context_menu.add_separator()
+	context_menu.add_item("System Info", 2)
+	context_menu.id_pressed.connect(_on_context_menu_id_pressed)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			context_menu.position = Vector2i(get_global_mouse_position())
+			context_menu.popup()
+			get_viewport().set_input_as_handled()
+
+
+func _on_context_menu_id_pressed(id: int) -> void:
+	match id:
+		0:
+			# TODO: load terminal scene and call window_manager.spawn_tool_window(...)
+			EventBus.log_message.emit("Terminal: not yet implemented", "info")
+		1:
+			# TODO: load network map scene
+			EventBus.log_message.emit("Network Map: not yet implemented", "info")
+		2:
+			var handle: String = GameManager.player_data.get("handle", "ghost")
+			EventBus.log_message.emit(
+				"DeltaTerminal v2 — handle: %s  credits: %d  rating: %d" % [
+					handle,
+					GameManager.player_data.get("credits", 0),
+					GameManager.player_data.get("rating", 1),
+				],
+				"info"
+			)

--- a/scenes/desktop/desktop.gd.uid
+++ b/scenes/desktop/desktop.gd.uid
@@ -1,0 +1,1 @@
+uid://drbpe4t7ta1wi

--- a/scenes/desktop/desktop.tscn
+++ b/scenes/desktop/desktop.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=7 format=3 uid="uid://cdeskabcdef012"]
+
+[ext_resource type="Script" path="res://scenes/desktop/desktop.gd" id="1_desk"]
+[ext_resource type="Script" path="res://scenes/desktop/window_manager.gd" id="2_wm"]
+[ext_resource type="Script" path="res://scenes/desktop/taskbar.gd" id="3_tb"]
+[ext_resource type="Shader" path="res://scenes/desktop/crt_background.gdshader" id="4_crt"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_bg"]
+shader = ExtResource("4_crt")
+shader_parameter/base_color = Color(0.02, 0.06, 0.02, 1)
+
+[node name="Desktop" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1_desk")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+material = SubResource("ShaderMaterial_bg")
+color = Color(0.02, 0.06, 0.02, 1)
+mouse_filter = 2
+
+[node name="WindowLayer" type="Control" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -36.0
+clip_contents = true
+script = ExtResource("2_wm")
+
+[node name="Taskbar" type="Panel" parent="."]
+layout_mode = 1
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -36.0
+script = ExtResource("3_tb")
+
+[node name="TaskItems" type="HBoxContainer" parent="Taskbar"]
+layout_mode = 1
+anchor_bottom = 1.0
+anchor_right = 1.0
+offset_left = 8.0
+offset_right = -128.0
+
+[node name="ClockLabel" type="Label" parent="Taskbar"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -120.0
+offset_right = -8.0
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="ContextMenu" type="PopupMenu" parent="."]

--- a/scenes/desktop/taskbar.gd
+++ b/scenes/desktop/taskbar.gd
@@ -1,0 +1,53 @@
+class_name Taskbar
+extends Panel
+## Taskbar / dock showing open tool buttons and a system clock.
+## Reacts to EventBus.tool_opened / tool_closed.
+
+@onready var task_items: HBoxContainer = $TaskItems
+@onready var clock_label: Label = $ClockLabel
+
+# tool_name -> Button
+var _task_buttons: Dictionary = {}
+
+
+func _ready() -> void:
+	EventBus.tool_opened.connect(_on_tool_opened)
+	EventBus.tool_closed.connect(_on_tool_closed)
+	_apply_theme()
+	_update_clock()
+
+
+func _process(_delta: float) -> void:
+	_update_clock()
+
+
+func _apply_theme() -> void:
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color(0.04, 0.10, 0.04)
+	style.border_color = Color(0.0, 0.7, 0.25)
+	style.border_width_top = 1
+	add_theme_stylebox_override("panel", style)
+
+	clock_label.add_theme_color_override("font_color", Color(0.0, 1.0, 0.3))
+
+
+func _update_clock() -> void:
+	var t := Time.get_time_dict_from_system()
+	clock_label.text = "%02d:%02d:%02d" % [t.hour, t.minute, t.second]
+
+
+func _on_tool_opened(p_tool_name: String) -> void:
+	if _task_buttons.has(p_tool_name):
+		return
+
+	var btn := Button.new()
+	btn.text = "[ %s ]" % p_tool_name
+	btn.add_theme_color_override("font_color", Color(0.0, 1.0, 0.3))
+	task_items.add_child(btn)
+	_task_buttons[p_tool_name] = btn
+
+
+func _on_tool_closed(p_tool_name: String) -> void:
+	if _task_buttons.has(p_tool_name):
+		_task_buttons[p_tool_name].queue_free()
+		_task_buttons.erase(p_tool_name)

--- a/scenes/desktop/taskbar.gd.uid
+++ b/scenes/desktop/taskbar.gd.uid
@@ -1,0 +1,1 @@
+uid://ogabhcn6r2p

--- a/scenes/desktop/tool_window.gd
+++ b/scenes/desktop/tool_window.gd
@@ -1,0 +1,81 @@
+class_name ToolWindow
+extends Control
+## Base draggable tool window. Instantiate this scene (or a scene inheriting it)
+## via WindowManager.spawn_tool_window(). Never add directly to the scene tree.
+
+signal window_closed(tool_name: String)
+signal window_focused(tool_name: String)
+
+@export var tool_name: String = "Tool"
+
+var _dragging: bool = false
+var _drag_offset: Vector2 = Vector2.ZERO
+
+@onready var title_bar: Panel = $TitleBar
+@onready var title_label: Label = $TitleBar/TitleLabel
+@onready var close_button: Button = $TitleBar/CloseButton
+@onready var content_area: Control = $ContentArea
+
+
+func _ready() -> void:
+	title_label.text = tool_name
+	close_button.pressed.connect(_on_close_pressed)
+	title_bar.gui_input.connect(_on_title_bar_input)
+	gui_input.connect(_on_self_input)
+	_apply_theme()
+
+
+func _apply_theme() -> void:
+	var title_style := StyleBoxFlat.new()
+	title_style.bg_color = Color(0.04, 0.12, 0.04)
+	title_style.border_color = Color(0.0, 0.8, 0.3)
+	title_style.set_border_width_all(1)
+	title_bar.add_theme_stylebox_override("panel", title_style)
+
+	var window_style := StyleBoxFlat.new()
+	window_style.bg_color = Color(0.02, 0.06, 0.02, 0.95)
+	window_style.border_color = Color(0.0, 0.8, 0.3)
+	window_style.set_border_width_all(1)
+	add_theme_stylebox_override("panel", window_style)
+
+	title_label.add_theme_color_override("font_color", Color(0.0, 1.0, 0.3))
+	close_button.add_theme_color_override("font_color", Color(1.0, 0.3, 0.3))
+
+
+func _on_self_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		window_focused.emit(tool_name)
+
+
+func _on_title_bar_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_LEFT:
+			if event.pressed:
+				_dragging = true
+				_drag_offset = get_global_mouse_position() - global_position
+				window_focused.emit(tool_name)
+			else:
+				_dragging = false
+			get_viewport().set_input_as_handled()
+	elif event is InputEventMouseMotion and _dragging:
+		global_position = get_global_mouse_position() - _drag_offset
+		_clamp_to_screen()
+		get_viewport().set_input_as_handled()
+
+
+func _clamp_to_screen() -> void:
+	var screen_size := get_viewport_rect().size
+	global_position.x = clamp(global_position.x, 0.0, screen_size.x - size.x)
+	global_position.y = clamp(global_position.y, 0.0, screen_size.y - size.y)
+
+
+func set_tool_name(name: String) -> void:
+	tool_name = name
+	if is_node_ready() and title_label:
+		title_label.text = name
+
+
+func _on_close_pressed() -> void:
+	window_closed.emit(tool_name)
+	EventBus.tool_closed.emit(tool_name)
+	queue_free()

--- a/scenes/desktop/tool_window.gd.uid
+++ b/scenes/desktop/tool_window.gd.uid
@@ -1,0 +1,1 @@
+uid://bjlevpitwgv6l

--- a/scenes/desktop/tool_window.tscn
+++ b/scenes/desktop/tool_window.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=2 format=3 uid="uid://ctwabcdef01234"]
+
+[ext_resource type="Script" path="res://scenes/desktop/tool_window.gd" id="1_tw"]
+
+[node name="ToolWindow" type="Control"]
+custom_minimum_size = Vector2(320, 220)
+script = ExtResource("1_tw")
+
+[node name="TitleBar" type="Panel" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+offset_bottom = 28.0
+
+[node name="TitleLabel" type="Label" parent="TitleBar"]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_right = -32.0
+vertical_alignment = 1
+text = "Tool"
+
+[node name="CloseButton" type="Button" parent="TitleBar"]
+layout_mode = 1
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -30.0
+offset_right = -2.0
+offset_top = 2.0
+offset_bottom = -2.0
+text = "x"
+
+[node name="ContentArea" type="Control" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 28.0

--- a/scenes/desktop/window_manager.gd
+++ b/scenes/desktop/window_manager.gd
@@ -1,0 +1,54 @@
+class_name WindowManager
+extends Control
+## Manages spawning, layering (z-index), dragging, and closing of tool windows.
+## Lives as a child of the Desktop scene; tool windows are added as children here.
+
+# tool_name -> ToolWindow node
+var open_windows: Dictionary = {}
+
+
+func _ready() -> void:
+	EventBus.tool_closed.connect(_on_tool_closed)
+
+
+## Spawns a new tool window from a PackedScene, or focuses it if already open.
+## Emits EventBus.tool_opened on success.
+func spawn_tool_window(tool_scene: PackedScene, p_tool_name: String) -> ToolWindow:
+	if open_windows.has(p_tool_name):
+		_focus_window(open_windows[p_tool_name])
+		return open_windows[p_tool_name]
+
+	var window: ToolWindow = tool_scene.instantiate()
+	window.set_tool_name(p_tool_name)
+	add_child(window)
+
+	# Cascade position so multiple windows don't stack exactly
+	var screen_size := get_viewport_rect().size
+	var cascade := Vector2(30.0, 30.0) * float(open_windows.size() % 8)
+	window.position = (screen_size / 2.0 - window.custom_minimum_size / 2.0) + cascade
+
+	window.window_focused.connect(_on_window_focused)
+
+	open_windows[p_tool_name] = window
+	_focus_window(window)
+	EventBus.tool_opened.emit(p_tool_name)
+	return window
+
+
+func _focus_window(window: ToolWindow) -> void:
+	if not is_instance_valid(window):
+		return
+	move_child(window, get_child_count() - 1)
+
+
+func _on_window_focused(p_tool_name: String) -> void:
+	if open_windows.has(p_tool_name):
+		_focus_window(open_windows[p_tool_name])
+
+
+func _on_tool_closed(p_tool_name: String) -> void:
+	open_windows.erase(p_tool_name)
+
+
+func get_open_tool_names() -> Array:
+	return open_windows.keys()

--- a/scenes/desktop/window_manager.gd.uid
+++ b/scenes/desktop/window_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://byvw0ae1r6jbc

--- a/scripts/autoloads/event_bus.gd.uid
+++ b/scripts/autoloads/event_bus.gd.uid
@@ -1,0 +1,1 @@
+uid://d3qlpsleeiirl

--- a/scripts/autoloads/game_manager.gd.uid
+++ b/scripts/autoloads/game_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://72x7dr8ibrkl

--- a/scripts/autoloads/network_sim.gd.uid
+++ b/scripts/autoloads/network_sim.gd.uid
@@ -1,0 +1,1 @@
+uid://bemejee1ky8nx


### PR DESCRIPTION
## Summary
Implements the root desktop scene as an in-game OS shell with window management capabilities. Adds WindowManager for spawning and layering tool windows, Taskbar with live system clock and tool indicators, and a reusable ToolWindow base scene with draggable windows. Includes CRT background shader with scanlines, animated noise, and vignette effect.

## What's new
- `desktop.tscn` as main scene with background, window layer, taskbar, and context menu
- `WindowManager` class for spawning windows, managing z-index, drag tracking
- `Taskbar` class that displays open tools and updates clock
- `ToolWindow` base scene for draggable windows with title bar and close button
- CRT-style background shader with configurable scanlines and effects
- System integration via EventBus signals (tool_opened/tool_closed)
- Right-click context menu (stubs for Terminal, Network Map, System Info)

## Test plan
- Open desktop scene in Godot 4.6
- Verify CRT background renders with scanlines and animated noise
- Confirm taskbar appears at bottom with clock updating
- Right-click to open context menu
- Verify no errors in console when tool_opened/tool_closed events emit