### PR TITLE
Add world map network view and fullscreen mode

### DIFF
--- a/scenes/desktop/desktop.gd
+++ b/scenes/desktop/desktop.gd
@@ -67,7 +67,12 @@ func _show_context_menu(at_position: Vector2) -> void:
 func _on_open_tool_requested(tool_name: String) -> void:
 	match tool_name:
 		"Network Map":
-			window_manager.spawn_tool_window(NetworkMapScene, "Network Map")
+			if window_manager.open_windows.has("Network Map"):
+				var w: ToolWindow = window_manager.open_windows["Network Map"]
+				EventBus.tool_closed.emit("Network Map")
+				w.queue_free()
+			else:
+				window_manager.spawn_tool_window(NetworkMapScene, "Network Map")
 
 
 func _on_context_menu_id_pressed(id: int) -> void:

--- a/scenes/tools/network_map.gd
+++ b/scenes/tools/network_map.gd
@@ -29,6 +29,15 @@ func _ready() -> void:
 	_apply_info_panel_theme()
 	_populate_map()
 	_clear_info_panel()
+	# Fullscreen: disable drag and anchor to fill the WindowLayer next frame
+	# (deferred so it runs after WindowManager sets the initial position)
+	title_bar.gui_input.disconnect(_on_title_bar_input)
+	call_deferred("_enforce_fullscreen")
+
+
+func _enforce_fullscreen() -> void:
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	custom_minimum_size = Vector2.ZERO
 
 
 # ── Map population ─────────────────────────────────────────────────────────────

--- a/scenes/tools/network_map.tscn
+++ b/scenes/tools/network_map.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Script" path="res://scenes/tools/network_map_canvas.gd" id="3_nmc"]
 
 [node name="NetworkMap" instance=ExtResource("1_tw")]
-custom_minimum_size = Vector2(700, 460)
+custom_minimum_size = Vector2(0, 0)
 script = ExtResource("2_nm")
 
 [node name="HSplit" type="HSplitContainer" parent="ContentArea"]

--- a/scenes/tools/network_map_canvas.gd
+++ b/scenes/tools/network_map_canvas.gd
@@ -1,7 +1,78 @@
 class_name NetworkMapCanvas
 extends Control
-## Draws connection edges between network nodes.
+## Draws the world map background (coordinate grid + continent outlines) and
+## connection edges between network nodes.
 ## Node widgets are added as children and positioned by NetworkMap.
+
+# ── Projection constants ─────────────────────────────────────────────────────
+const LAT_MIN: float = -55.0
+const LAT_MAX: float =  80.0
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+const _COL_CONTINENT_FILL    := Color(0.0, 0.88, 1.0, 0.04)
+const _COL_CONTINENT_OUTLINE := Color(0.0, 0.88, 1.0, 0.18)
+const _COL_GRID              := Color(0.0, 0.88, 1.0, 0.06)
+const _COL_EQUATOR           := Color(0.0, 0.88, 1.0, 0.12)
+
+# ── Continent outlines (each point is Vector2(longitude, latitude)) ───────────
+var _continent_outlines: Array = [
+	# North America
+	[
+		Vector2(-168, 71), Vector2(-141, 60), Vector2(-124, 49),
+		Vector2(-117, 32), Vector2(-105, 23), Vector2(-90,  16),
+		Vector2(-83,  10), Vector2(-82,  25), Vector2(-74,  40),
+		Vector2(-66,  44), Vector2(-56,  47), Vector2(-60,  52),
+		Vector2(-85,  72), Vector2(-140, 73), Vector2(-168, 71),
+	],
+	# South America
+	[
+		Vector2(-80,   9), Vector2(-63,  11), Vector2(-35,  -5),
+		Vector2(-34, -22), Vector2(-50, -33), Vector2(-65, -55),
+		Vector2(-67, -56), Vector2(-71, -52), Vector2(-75, -45),
+		Vector2(-71, -30), Vector2(-70, -15), Vector2(-77,  -1),
+		Vector2(-80,   9),
+	],
+	# Europe
+	[
+		Vector2( -9, 36), Vector2( -9, 44), Vector2( -4, 48),
+		Vector2(  2, 51), Vector2(  8, 55), Vector2( 10, 60),
+		Vector2( 28, 71), Vector2( 30, 70), Vector2( 24, 59),
+		Vector2( 28, 60), Vector2( 30, 60), Vector2( 30, 50),
+		Vector2( 28, 42), Vector2( 36, 37), Vector2( 26, 38),
+		Vector2( 22, 40), Vector2( 14, 38), Vector2(  3, 37),
+		Vector2( -8, 36), Vector2( -9, 36),
+	],
+	# Africa
+	[
+		Vector2( -6, 36), Vector2( 10, 37), Vector2( 32, 31),
+		Vector2( 43, 12), Vector2( 51, 12), Vector2( 43,-12),
+		Vector2( 35,-25), Vector2( 18,-34), Vector2( 12,-28),
+		Vector2(  0, -5), Vector2(-17, 15), Vector2( -6, 36),
+	],
+	# Asia (main body; India, SE Asia, and Arabian Peninsula included in outline)
+	[
+		Vector2( 26, 38), Vector2( 40, 42), Vector2( 52, 42),
+		Vector2( 60, 50), Vector2( 95, 55), Vector2(130, 55),
+		Vector2(141, 50), Vector2(145, 43), Vector2(140, 35),
+		Vector2(122, 28), Vector2(110, 18), Vector2(100,  1),
+		Vector2( 90, 22), Vector2( 80, 10), Vector2( 72, 22),
+		Vector2( 60, 25), Vector2( 43, 22), Vector2( 37, 22),
+		Vector2( 34, 28), Vector2( 36, 37), Vector2( 26, 38),
+	],
+	# Australia
+	[
+		Vector2(113,-22), Vector2(116,-34), Vector2(130,-33),
+		Vector2(137,-35), Vector2(145,-38), Vector2(152,-28),
+		Vector2(150,-20), Vector2(143,-17), Vector2(135,-13),
+		Vector2(128,-14), Vector2(122,-18), Vector2(113,-22),
+	],
+	# Greenland
+	[
+		Vector2(-25, 71), Vector2(-18, 77), Vector2(-25, 83),
+		Vector2(-38, 83), Vector2(-52, 82), Vector2(-57, 76),
+		Vector2(-44, 60), Vector2(-40, 65), Vector2(-25, 71),
+	],
+]
 
 var _edges: Array = []  # Array of { from:Vector2, to:Vector2, color:Color, width:float }
 
@@ -11,6 +82,34 @@ func update_edges(edges: Array) -> void:
 	queue_redraw()
 
 
+func _geo_to_canvas(lon: float, lat: float) -> Vector2:
+	return Vector2(
+		(lon + 180.0) / 360.0 * size.x,
+		(LAT_MAX - lat) / (LAT_MAX - LAT_MIN) * size.y
+	)
+
+
 func _draw() -> void:
+	if size.x < 1.0 or size.y < 1.0:
+		return
+	_draw_grid()
+	_draw_continents()
 	for edge in _edges:
 		draw_line(edge.from, edge.to, edge.color, edge.width, true)
+
+
+func _draw_grid() -> void:
+	for lat: float in [-30.0, 0.0, 30.0, 60.0]:
+		var col := _COL_EQUATOR if lat == 0.0 else _COL_GRID
+		draw_line(_geo_to_canvas(-180.0, lat), _geo_to_canvas(180.0, lat), col, 1.0)
+	for lon: float in [-150.0, -120.0, -90.0, -60.0, -30.0, 0.0, 30.0, 60.0, 90.0, 120.0, 150.0]:
+		draw_line(_geo_to_canvas(lon, LAT_MAX), _geo_to_canvas(lon, LAT_MIN), _COL_GRID, 1.0)
+
+
+func _draw_continents() -> void:
+	for outline: Array in _continent_outlines:
+		var pts := PackedVector2Array()
+		for p: Vector2 in outline:
+			pts.append(_geo_to_canvas(p.x, p.y))
+		draw_colored_polygon(pts, _COL_CONTINENT_FILL)
+		draw_polyline(pts, _COL_CONTINENT_OUTLINE, 1.0)

--- a/scripts/autoloads/network_sim.gd
+++ b/scripts/autoloads/network_sim.gd
@@ -115,7 +115,9 @@ func delete_file_from_node(node_id: String, file_id: String) -> bool:
 
 func _register_default_nodes() -> void:
 	# Starting network — replace with data-driven loading later.
-	# map_position: pixel coords on the NetworkMapCanvas (~490 × 420 visible area)
+	# map_position: pixel coords on the NetworkMapCanvas, equirectangular projection.
+	#   x = (lon + 180) / 360 * canvas_w   (canvas_w ≈ 700)
+	#   y = (80 - lat)  / 135 * canvas_h   (canvas_h ≈ 510, lat range −55 to +80)
 	# connections: array of node IDs this node has a known route to
 
 	register_node({
@@ -123,7 +125,7 @@ func _register_default_nodes() -> void:
 		"ip": "127.0.0.1",
 		"name": "Local Machine",
 		"security": 0,
-		"map_position": Vector2(70, 200),
+		"map_position": Vector2(334, 102),  # Ireland / West UK  (53°N, 8°W)
 		"files": [],
 		"services": [],
 		"connections": ["isp_01", "isp_02"],
@@ -133,7 +135,7 @@ func _register_default_nodes() -> void:
 		"ip": "81.14.22.1",
 		"name": "Sentinel ISP",
 		"security": 1,
-		"map_position": Vector2(210, 110),
+		"map_position": Vector2(399, 68),   # Scandinavia / Sweden  (62°N, 25°E)
 		"files": [
 			{
 				"id": "isp01_f1",
@@ -149,9 +151,9 @@ func _register_default_nodes() -> void:
 	register_node({
 		"id": "isp_02",
 		"ip": "81.14.22.2",
-		"name": "Sentinel ISP (Backup)",
+		"name": "Sentinel ISP (Asia-Pacific)",
 		"security": 1,
-		"map_position": Vector2(210, 300),
+		"map_position": Vector2(552, 297),  # Singapore  (1°N, 104°E)
 		"files": [],
 		"services": ["relay"],
 		"connections": ["corp_01", "darknet_01"],
@@ -161,7 +163,7 @@ func _register_default_nodes() -> void:
 		"ip": "193.62.18.5",
 		"name": "NeoTech University",
 		"security": 2,
-		"map_position": Vector2(370, 60),
+		"map_position": Vector2(621, 167),  # Tokyo, Japan  (36°N, 140°E)
 		"files": [
 			{
 				"id": "univ01_f1",
@@ -186,7 +188,7 @@ func _register_default_nodes() -> void:
 		"ip": "84.23.119.41",
 		"name": "ArcTech Systems",
 		"security": 3,
-		"map_position": Vector2(370, 200),
+		"map_position": Vector2(206, 148),  # New York, USA  (41°N, 74°W)
 		"files": [
 			{
 				"id": "corp01_f1",
@@ -218,7 +220,7 @@ func _register_default_nodes() -> void:
 		"ip": "10.0.13.37",
 		"name": "Darknet Relay",
 		"security": 2,
-		"map_position": Vector2(370, 350),
+		"map_position": Vector2(535, 83),   # Siberia, Russia  (58°N, 95°E)
 		"files": [
 			{
 				"id": "dark01_f1",


### PR DESCRIPTION
## Summary

- **World map background**: The network map canvas now draws a recognisable equirectangular world map — lat/lon coordinate grid (every 30°, equator slightly brighter) and simplified polygon outlines for North America, South America, Europe, Africa, Asia, Australia, and Greenland, filled with a subtle cyan tint.
- **Geographic node distribution**: All 6 default nodes are repositioned to real-world locations — Local Machine (Ireland), Sentinel ISP (Scandinavia), Sentinel ISP renamed to Asia-Pacific (Singapore), NeoTech University (Tokyo), ArcTech Systems (New York), Darknet Relay (Siberia). Minimum node separation is ≥ 72 px, no icon overlap.
- **Fullscreen Network Map**: The map opens as a fixed panel that fills the entire WindowLayer (respects sidebar and taskbar), rather than a floating draggable window. Title-bar drag is disabled; close button still works.
- **Minimap toggle**: Clicking the sidebar minimap now toggles the Network Map — opens it if closed, closes it if already open.

## Test plan

- [ ] Right-click desktop → open Network Map — confirm it fills the main area (not a floating window)
- [ ] Confirm continent outlines and grid lines are visible
- [ ] Confirm all 6 nodes are spread across the world map with correct geographic placement
- [ ] Click each node — info panel updates correctly
- [ ] Double-click a node / press CONNECT — connection and edge highlight work
- [ ] Close via the title bar ✕ button
- [ ] Click the sidebar minimap — map opens; click again — map closes (toggle)
- [ ] Open another tool (Password Cracker, etc.) while map is open — other tools appear on top