### PR TITLE
Add SystemView: full-screen system interface background

### DIFF
--- a/scenes/desktop/desktop.tscn
+++ b/scenes/desktop/desktop.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Script" uid="uid://ogabhcn6r2p" path="res://scenes/desktop/taskbar.gd" id="3_tb"]
 [ext_resource type="Shader" uid="uid://b0bc2h4d8a5fo" path="res://scenes/desktop/crt_background.gdshader" id="4_crt"]
 [ext_resource type="PackedScene" uid="uid://ct2jvkb2t0vuh" path="res://scenes/desktop/sidebar.tscn" id="5_sb"]
+[ext_resource type="PackedScene" path="res://scenes/tools/system_view.tscn" id="6_sv"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_bg"]
 shader = ExtResource("4_crt")
@@ -33,6 +34,13 @@ anchor_bottom = 1.0
 mouse_filter = 2
 color = Color(0.03, 0.02, 0.08, 1)
 
+[node name="SystemView" parent="." instance=ExtResource("6_sv")]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_bottom = -36.0
+
 [node name="WindowLayer" type="Control" parent="." unique_id=1575868660]
 clip_contents = true
 layout_mode = 1
@@ -41,6 +49,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_right = -220.0
 offset_bottom = -36.0
+mouse_filter = 2
 script = ExtResource("2_wm")
 
 [node name="Taskbar" type="Panel" parent="." unique_id=1455385100]

--- a/scenes/tools/system_view.gd
+++ b/scenes/tools/system_view.gd
@@ -1,0 +1,220 @@
+class_name SystemView
+extends Control
+## Full-screen background view of the currently connected node.
+## Sits between the CRT background and the floating tool windows.
+## Hidden when not connected; shows public interfaces or a private login screen.
+
+# ── Colour constants ───────────────────────────────────────────────────────────
+const COL_CYAN  := Color(0.0,  0.88, 1.0)
+const COL_PINK  := Color(1.0,  0.08, 0.55)
+const COL_AMBER := Color(1.0,  0.75, 0.0)
+const COL_MUTED := Color(0.35, 0.35, 0.45)
+const COL_LIGHT := Color(0.75, 0.92, 1.0)
+
+const PROTECTION_COLOURS: Dictionary = {
+	"firewall":   COL_PINK,
+	"proxy":      COL_AMBER,
+	"encryption": COL_CYAN,
+}
+
+# ── Node refs ──────────────────────────────────────────────────────────────────
+@onready var _header:            Panel           = $Header
+@onready var _sys_name_label:    Label           = $Header/HBox/SysNameLabel
+@onready var _ip_label:          Label           = $Header/HBox/IPLabel
+@onready var _public_section:    CenterContainer = $PublicSection
+@onready var _interface_flow:    HFlowContainer  = $PublicSection/InterfaceFlow
+@onready var _private_section:   CenterContainer = $PrivateSection
+@onready var _login_box:         PanelContainer  = $PrivateSection/LoginBox
+@onready var _private_label:     Label           = $PrivateSection/LoginBox/Margin/VBox/PrivateLabel
+@onready var _auth_label:        Label           = $PrivateSection/LoginBox/Margin/VBox/AuthLabel
+@onready var _attempt_btn:       Button          = $PrivateSection/LoginBox/Margin/VBox/AttemptBtn
+@onready var _protections_panel: VBoxContainer   = $PrivateSection/LoginBox/Margin/VBox/ProtectionsPanel
+
+
+func _ready() -> void:
+	EventBus.network_connected.connect(_on_network_connected)
+	EventBus.network_disconnected.connect(_on_network_disconnected)
+	_attempt_btn.pressed.connect(_on_attempt_login)
+	_apply_theme()
+
+
+# ── EventBus handlers ──────────────────────────────────────────────────────────
+
+func _on_network_connected(node_id: String) -> void:
+	_populate(node_id)
+
+
+func _on_network_disconnected() -> void:
+	visible = false
+	_clear_interfaces()
+	_clear_protections()
+
+
+# ── Populate ───────────────────────────────────────────────────────────────────
+
+func _populate(node_id: String) -> void:
+	var data: Dictionary  = NetworkSim.get_node_data(node_id)
+	var interfaces: Array = data.get("public_interfaces", [])
+
+	_sys_name_label.text = data.get("name", "Unknown").to_upper()
+	_ip_label.text       = data.get("ip",   "0.0.0.0")
+
+	_clear_interfaces()
+	_clear_protections()
+	_attempt_btn.visible       = true
+	_protections_panel.visible = false
+	visible                    = true
+
+	if interfaces.is_empty():
+		_public_section.visible  = false
+		_private_section.visible = true
+	else:
+		_public_section.visible  = true
+		_private_section.visible = false
+		for iface: Dictionary in interfaces:
+			_add_interface_card(iface, data.get("name", "?"))
+
+
+# ── Interface cards ────────────────────────────────────────────────────────────
+
+func _add_interface_card(iface: Dictionary, node_name: String) -> void:
+	var iface_name: String = iface.get("name",        "Interface")
+	var desc:       String = iface.get("description", "")
+
+	var card := PanelContainer.new()
+	card.custom_minimum_size = Vector2(200, 110)
+	var card_style := StyleBoxFlat.new()
+	card_style.bg_color     = Color(0.03, 0.05, 0.10, 0.92)
+	card_style.border_color = COL_CYAN
+	card_style.set_border_width_all(1)
+	card_style.set_corner_radius_all(2)
+	card_style.set_content_margin_all(12)
+	card.add_theme_stylebox_override("panel", card_style)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 6)
+
+	var icon_lbl := Label.new()
+	icon_lbl.text = "[>]"
+	icon_lbl.add_theme_color_override("font_color",    COL_CYAN)
+	icon_lbl.add_theme_font_size_override("font_size", 18)
+
+	var name_btn := Button.new()
+	name_btn.text         = iface_name
+	name_btn.flat         = true
+	name_btn.alignment    = HORIZONTAL_ALIGNMENT_LEFT
+	name_btn.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	name_btn.add_theme_color_override("font_color",         COL_CYAN)
+	name_btn.add_theme_color_override("font_hover_color",   Color.WHITE)
+	name_btn.add_theme_color_override("font_pressed_color", COL_LIGHT)
+
+	var cap_name:      String = iface_name
+	var cap_node_name: String = node_name
+	name_btn.pressed.connect(func() -> void:
+		EventBus.log_message.emit(
+			"[%s] Public interface accessed: %s" % [cap_node_name, cap_name], "info"
+		)
+	)
+
+	var desc_lbl := Label.new()
+	desc_lbl.text = desc
+	desc_lbl.add_theme_color_override("font_color", COL_MUTED)
+	desc_lbl.autowrap_mode        = TextServer.AUTOWRAP_WORD_SMART
+	desc_lbl.size_flags_vertical  = Control.SIZE_EXPAND_FILL
+
+	vbox.add_child(icon_lbl)
+	vbox.add_child(name_btn)
+	vbox.add_child(desc_lbl)
+	card.add_child(vbox)
+	_interface_flow.add_child(card)
+
+
+func _clear_interfaces() -> void:
+	for child in _interface_flow.get_children():
+		child.queue_free()
+
+
+# ── Attempt login / protections ────────────────────────────────────────────────
+
+func _on_attempt_login() -> void:
+	var data:  Dictionary = NetworkSim.get_node_data(NetworkSim.connected_node_id)
+	var prots: Array      = data.get("protections", [])
+
+	_attempt_btn.visible = false
+	_reveal_protections(prots)
+	EventBus.log_message.emit(
+		"[%s] Login attempted — access denied." % data.get("name", "?"), "warn"
+	)
+
+
+func _reveal_protections(prots: Array) -> void:
+	_clear_protections()
+	_protections_panel.visible = true
+
+	var denied_lbl := Label.new()
+	denied_lbl.text = "── ACCESS DENIED ──"
+	denied_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	denied_lbl.add_theme_color_override("font_color", COL_PINK)
+	_protections_panel.add_child(denied_lbl)
+
+	var section_lbl := Label.new()
+	section_lbl.text = "SECURITY STATUS"
+	section_lbl.add_theme_color_override("font_color", COL_MUTED)
+	_protections_panel.add_child(section_lbl)
+
+	if prots.is_empty():
+		var none_lbl := Label.new()
+		none_lbl.text = "  (no protections detected)"
+		none_lbl.add_theme_color_override("font_color", COL_MUTED)
+		_protections_panel.add_child(none_lbl)
+		return
+
+	for prot: Dictionary in prots:
+		var prot_type:  String = prot.get("type",  "unknown")
+		var prot_level: int    = prot.get("level", 1)
+		var col: Color         = PROTECTION_COLOURS.get(prot_type, COL_LIGHT)
+
+		var row := HBoxContainer.new()
+
+		var type_lbl := Label.new()
+		type_lbl.text = prot_type.to_upper().rpad(12)
+		type_lbl.add_theme_color_override("font_color", col)
+		type_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+		var level_lbl := Label.new()
+		level_lbl.text = "LVL %d" % prot_level
+		level_lbl.add_theme_color_override("font_color", col)
+
+		row.add_child(type_lbl)
+		row.add_child(level_lbl)
+		_protections_panel.add_child(row)
+
+
+func _clear_protections() -> void:
+	for child in _protections_panel.get_children():
+		child.queue_free()
+
+
+# ── Theme ──────────────────────────────────────────────────────────────────────
+
+func _apply_theme() -> void:
+	var header_style := StyleBoxFlat.new()
+	header_style.bg_color             = Color(0.04, 0.03, 0.12, 0.92)
+	header_style.border_color         = COL_CYAN
+	header_style.border_width_bottom  = 1
+	_header.add_theme_stylebox_override("panel", header_style)
+
+	var login_style := StyleBoxFlat.new()
+	login_style.bg_color     = Color(0.04, 0.03, 0.10, 0.96)
+	login_style.border_color = COL_PINK
+	login_style.set_border_width_all(1)
+	login_style.set_content_margin_all(0)
+	_login_box.add_theme_stylebox_override("panel", login_style)
+
+	_sys_name_label.add_theme_color_override("font_color",    COL_CYAN)
+	_sys_name_label.add_theme_font_size_override("font_size", 16)
+	_ip_label.add_theme_color_override("font_color",          COL_MUTED)
+	_private_label.add_theme_color_override("font_color",     COL_PINK)
+	_private_label.add_theme_font_size_override("font_size",  15)
+	_auth_label.add_theme_color_override("font_color",        COL_MUTED)
+	_attempt_btn.add_theme_color_override("font_color",       COL_AMBER)

--- a/scenes/tools/system_view.tscn
+++ b/scenes/tools/system_view.tscn
@@ -1,0 +1,88 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/tools/system_view.gd" id="1_sv"]
+
+[node name="SystemView" type="Control"]
+script = ExtResource("1_sv")
+visible = false
+mouse_filter = 2
+
+[node name="Header" type="Panel" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+offset_bottom = 50.0
+
+[node name="HBox" type="HBoxContainer" parent="Header"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 16.0
+offset_right = -16.0
+theme_override_constants/separation = 12
+
+[node name="SysNameLabel" type="Label" parent="Header/HBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+vertical_alignment = 1
+
+[node name="IPLabel" type="Label" parent="Header/HBox"]
+layout_mode = 2
+vertical_alignment = 1
+
+[node name="PublicSection" type="CenterContainer" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 50.0
+visible = false
+mouse_filter = 2
+
+[node name="InterfaceFlow" type="HFlowContainer" parent="PublicSection"]
+layout_mode = 2
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 16
+
+[node name="PrivateSection" type="CenterContainer" parent="."]
+layout_mode = 1
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = 50.0
+visible = false
+
+[node name="LoginBox" type="PanelContainer" parent="PrivateSection"]
+custom_minimum_size = Vector2(300, 0)
+
+[node name="Margin" type="MarginContainer" parent="PrivateSection/LoginBox"]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="VBox" type="VBoxContainer" parent="PrivateSection/LoginBox/Margin"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="PrivateLabel" type="Label" parent="PrivateSection/LoginBox/Margin/VBox"]
+layout_mode = 2
+text = "[##]  PRIVATE SYSTEM"
+horizontal_alignment = 1
+
+[node name="AuthLabel" type="Label" parent="PrivateSection/LoginBox/Margin/VBox"]
+layout_mode = 2
+text = "Authentication required"
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="LoginSep" type="HSeparator" parent="PrivateSection/LoginBox/Margin/VBox"]
+layout_mode = 2
+
+[node name="AttemptBtn" type="Button" parent="PrivateSection/LoginBox/Margin/VBox"]
+layout_mode = 2
+text = "ATTEMPT LOGIN"
+
+[node name="ProtectionsPanel" type="VBoxContainer" parent="PrivateSection/LoginBox/Margin/VBox"]
+layout_mode = 2
+visible = false
+theme_override_constants/separation = 6

--- a/scripts/autoloads/network_sim.gd
+++ b/scripts/autoloads/network_sim.gd
@@ -2,7 +2,7 @@ extends Node
 ## Simulates the in-game network. Tracks nodes, active connection, and bounce chain.
 
 # ── Node registry ─────────────────────────────────────────────────────────────
-# Each node: { id, ip, name, security, files: [], services: [] }
+# Each node: { id, ip, name, security, files: [], services: [], public_interfaces: [], protections: [] }
 var nodes: Dictionary = {}
 
 # ── Active session ─────────────────────────────────────────────────────────────
@@ -129,6 +129,8 @@ func _register_default_nodes() -> void:
 		"files": [],
 		"services": [],
 		"connections": ["isp_01", "isp_02"],
+		"public_interfaces": [],
+		"protections": [],
 	})
 	register_node({
 		"id": "isp_01",
@@ -147,6 +149,12 @@ func _register_default_nodes() -> void:
 		],
 		"services": ["relay"],
 		"connections": ["univ_01", "corp_01"],
+		"public_interfaces": [
+			{"name": "ISP Customer Portal", "description": "Account management and service status"},
+		],
+		"protections": [
+			{"type": "firewall", "level": 1},
+		],
 	})
 	register_node({
 		"id": "isp_02",
@@ -157,6 +165,12 @@ func _register_default_nodes() -> void:
 		"files": [],
 		"services": ["relay"],
 		"connections": ["corp_01", "darknet_01"],
+		"public_interfaces": [
+			{"name": "ISP Customer Portal", "description": "Account management and service status"},
+		],
+		"protections": [
+			{"type": "firewall", "level": 1},
+		],
 	})
 	register_node({
 		"id": "univ_01",
@@ -182,6 +196,14 @@ func _register_default_nodes() -> void:
 		],
 		"services": [],
 		"connections": ["corp_01"],
+		"public_interfaces": [
+			{"name": "Student Portal", "description": "Course registration and academic records"},
+			{"name": "Research Database", "description": "Public research publications"},
+		],
+		"protections": [
+			{"type": "firewall", "level": 1},
+			{"type": "proxy",    "level": 1},
+		],
 	})
 	register_node({
 		"id": "corp_01",
@@ -214,6 +236,12 @@ func _register_default_nodes() -> void:
 		],
 		"services": [],
 		"connections": [],
+		"public_interfaces": [],
+		"protections": [
+			{"type": "firewall",   "level": 2},
+			{"type": "proxy",      "level": 1},
+			{"type": "encryption", "level": 1},
+		],
 	})
 	register_node({
 		"id": "darknet_01",
@@ -232,4 +260,9 @@ func _register_default_nodes() -> void:
 		],
 		"services": ["relay"],
 		"connections": ["corp_01"],
+		"public_interfaces": [],
+		"protections": [
+			{"type": "proxy",      "level": 2},
+			{"type": "encryption", "level": 1},
+		],
 	})


### PR DESCRIPTION
## Summary

Adds SystemView, a full-screen background tool that shows the connected node's public or private interface. When connecting to a node, the desktop background fills with that system's "desktop" — public systems display clickable interface cards (e.g., ISP portals, research databases), while private systems show a login barrier with security status (firewall/proxy/encryption levels) revealed on login attempt.

## Changes

- **Node data schema**: Added `public_interfaces` (array of {name, description}) and `protections` (array of {type, level}) to all six default nodes, modeling realistic system topology (public ISPs, private corporations, darknet relays)
- **SystemView tool**: New Control-based scene/script that fills the screen below floating tools, hidden until connected, with header bar showing system name/IP and content area that switches between public interface cards and private login dialog
- **Desktop integration**: Positioned SystemView between Background and WindowLayer in z-order, set WindowLayer `mouse_filter=2` so clicks in empty areas pass through to system view (preserving tool window interactivity), updated desktop.tscn to accommodate existing 220px sidebar
- **Rebase on main**: Merged with main branch changes (neo-Tokyo restyle, sidebar minimap, world map on Network Map tool)