### PR TITLE
Fix MissionData resource type in first_contact.tres

### DIFF
--- a/data/missions/first_contact.tres
+++ b/data/missions/first_contact.tres
@@ -1,4 +1,4 @@
-[gd_resource load_steps=5 format=3]
+[gd_resource type="MissionData" load_steps=5 format=3]
 
 [ext_resource type="Script" path="res://scripts/data/mission_data.gd" id="1_md"]
 [ext_resource type="Script" path="res://scripts/data/objective_data.gd" id="2_od"]


### PR DESCRIPTION
Added the missing 'type' field to the [gd_resource] header in the first_contact mission resource. Godot 4 requires this field to correctly deserialize custom Resource classes, which was causing a parse error when loading the mission data.