### PR TITLE
Implement save/load system with versioning and auto-save (issue #11)

### DIFF
--- a/scenes/desktop/desktop.gd
+++ b/scenes/desktop/desktop.gd
@@ -56,6 +56,8 @@ func _setup_context_menu() -> void:
 	context_menu.add_item("Hardware Viewer", 11)
 	context_menu.add_separator()
 	context_menu.add_item("Settings", 8)
+	context_menu.add_separator()
+	context_menu.add_item("Save Game", 12)
 	context_menu.id_pressed.connect(_on_context_menu_id_pressed)
 
 
@@ -118,6 +120,8 @@ func _on_context_menu_id_pressed(id: int) -> void:
 			)
 		8:
 			window_manager.spawn_tool_window(SettingsScene, "Settings")
+		12:
+			SaveManager.save_game()
 
 
 func _on_system_nuke() -> void:

--- a/scripts/autoloads/mission_manager.gd
+++ b/scripts/autoloads/mission_manager.gd
@@ -100,3 +100,16 @@ func _complete_mission(mission: MissionData) -> void:
 	EventBus.log_message.emit(
 		"Mission complete: %s  —  +%d credits" % [mission.title, mission.reward_credits], "info"
 	)
+
+
+# ── Save / load support ────────────────────────────────────────────────────────
+
+## Re-activates missions by id after a save is loaded.
+## Duplicates the mission template so objective state is fresh.
+func restore_active_missions(ids: Array) -> void:
+	for id in ids:
+		if not available_missions.has(id):
+			continue
+		if active_missions.has(id):
+			continue
+		active_missions[id] = available_missions[id].duplicate(true)

--- a/scripts/autoloads/save_manager.gd
+++ b/scripts/autoloads/save_manager.gd
@@ -1,7 +1,26 @@
 extends Node
 ## Handles serialising and restoring game state to/from user://save.json.
 
-const SAVE_PATH := "user://save.json"
+const SAVE_PATH    := "user://save.json"
+const SAVE_VERSION := 1
+
+
+func _ready() -> void:
+	EventBus.network_disconnected.connect(_autosave)
+	EventBus.mission_accepted.connect(_autosave_on_mission)
+	EventBus.mission_completed.connect(_autosave_on_mission)
+
+
+# ── Auto-save ──────────────────────────────────────────────────────────────────
+
+func _autosave() -> void:
+	if SettingsManager.autosave:
+		save_game()
+
+
+func _autosave_on_mission(_mission_id: String) -> void:
+	if SettingsManager.autosave:
+		save_game()
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -12,11 +31,14 @@ func has_save() -> bool:
 
 func save_game() -> void:
 	var data := {
-		"player_data":       GameManager.player_data.duplicate(),
-		"active_missions":   GameManager.active_missions.duplicate(),
-		"completed_missions":GameManager.completed_missions.duplicate(),
-		"cracked_nodes":     NetworkSim.cracked_nodes.duplicate(),
-		"hardware":          HardwareManager.get_save_data(),
+		"version":            SAVE_VERSION,
+		"player_data":        GameManager.player_data.duplicate(),
+		"active_missions":    GameManager.active_missions.duplicate(),
+		"completed_missions": GameManager.completed_missions.duplicate(),
+		"local_storage":      _serialize_local_storage(),
+		"cracked_nodes":      NetworkSim.cracked_nodes.duplicate(),
+		"node_state":         _collect_node_state(),
+		"hardware":           HardwareManager.get_save_data(),
 	}
 	var file := FileAccess.open(SAVE_PATH, FileAccess.WRITE)
 	if file:
@@ -37,15 +59,83 @@ func load_game() -> bool:
 		EventBus.log_message.emit("Save data corrupt — could not parse.", "error")
 		return false
 	var data: Dictionary = json.data
+	if not _check_version(data):
+		return false
 	GameManager.player_data = data.get("player_data", GameManager.player_data.duplicate())
 	GameManager.active_missions.assign(data.get("active_missions", []))
 	GameManager.completed_missions.assign(data.get("completed_missions", []))
+	GameManager.local_storage = _deserialize_local_storage(data.get("local_storage", []))
 	NetworkSim.cracked_nodes.assign(data.get("cracked_nodes", []))
+	_restore_node_state(data.get("node_state", {}))
 	if data.has("hardware"):
 		HardwareManager.load_save_data(data["hardware"])
+	MissionManager.restore_active_missions(GameManager.active_missions)
 	return true
 
 
 func delete_save() -> void:
 	if has_save():
 		DirAccess.remove_absolute(SAVE_PATH)
+
+
+# ── Serialisation helpers ──────────────────────────────────────────────────────
+
+func _serialize_local_storage() -> Array:
+	var result: Array = []
+	for f: Dictionary in GameManager.local_storage:
+		result.append(f.duplicate())
+	return result
+
+
+func _deserialize_local_storage(raw: Array) -> Array[Dictionary]:
+	var result: Array[Dictionary] = []
+	for entry in raw:
+		if entry is Dictionary:
+			result.append(entry)
+	return result
+
+
+## Captures per-node state that may have changed during a session:
+## file list (deletions) and scanned port results.
+func _collect_node_state() -> Dictionary:
+	var state: Dictionary = {}
+	for node_id: String in NetworkSim.nodes:
+		var node: Dictionary = NetworkSim.nodes[node_id]
+		var entry: Dictionary = {}
+		if node.has("files"):
+			var files: Array = []
+			for f: Dictionary in node["files"]:
+				files.append(f.duplicate())
+			entry["files"] = files
+		var ports: Array = node.get("scanned_ports", [])
+		if not ports.is_empty():
+			entry["scanned_ports"] = ports.duplicate()
+		if not entry.is_empty():
+			state[node_id] = entry
+	return state
+
+
+## Applies saved per-node state over the freshly-registered default nodes.
+func _restore_node_state(state: Dictionary) -> void:
+	for node_id: String in state:
+		if not NetworkSim.nodes.has(node_id):
+			continue
+		var entry: Dictionary = state[node_id]
+		if entry.has("files"):
+			NetworkSim.nodes[node_id]["files"] = entry["files"]
+		if entry.has("scanned_ports"):
+			NetworkSim.nodes[node_id]["scanned_ports"] = entry["scanned_ports"]
+
+
+func _check_version(data: Dictionary) -> bool:
+	var version: int = int(data.get("version", 0))
+	if version == 0:
+		# Legacy save without version field — attempt to load anyway.
+		push_warning("SaveManager: legacy save format detected, attempting load.")
+		return true
+	if version > SAVE_VERSION:
+		EventBus.log_message.emit(
+			"Save file is from a newer game version — cannot load.", "error"
+		)
+		return false
+	return true


### PR DESCRIPTION
## Summary

Adds a complete save/load persistence system to capture and restore all game state:
- Player data, mission progress, cracked nodes, and local file inventory now persist across sessions
- Introduces JSON versioning for forward-compatible save format migrations
- Auto-save on meaningful events (mission accepted/completed, network disconnected) when enabled
- Manual save available from desktop context menu ("Save Game")
- Per-node state (file modifications, port scan results) preserved on load
- Graceful handling of legacy/corrupted/incompatible saves

## Changes

**SaveManager**: Expanded from basic player data to capture version, local_storage, per-node state (files/scanned_ports), and hardware state. Auto-save hooks connect to EventBus signals and respect SettingsManager.autosave. Version check allows legacy saves and rejects incompatible future versions.

**MissionManager**: Added `restore_active_missions()` to re-activate in-progress missions after load by deep-duplicating mission templates.

**Desktop**: Added "Save Game" menu item (ID 12) to right-click context menu, calling SaveManager.save_game() directly.

Resolves #11.